### PR TITLE
jsd.nn.ci变更为cdn.jsdelivr.net

### DIFF
--- a/.github/workflows/auto_lang.yml
+++ b/.github/workflows/auto_lang.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout alist-web
         uses: actions/checkout@v4
         with:
-          repository: 'alist-org/alist-web'
+          repository: 'NodeSeekDev/nlist-web'
           ref: main
           persist-credentials: false
           fetch-depth: 0
@@ -68,4 +68,4 @@ jobs:
           github_token: ${{ secrets.MY_TOKEN }}
           branch: main
           directory: alist-web
-          repository: alist-org/alist-web
+          repository: NodeSeekDev/nlist-web

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           git config --local user.email "bot@nn.ci"
           git config --local user.name "IlaBot"
-          version=$(wget -qO- -t1 -T2 "https://api.github.com/repos/alist-org/alist/releases/latest" | grep "tag_name" | head -n 1 | awk -F ":" '{print $2}' | sed 's/\"//g;s/,//g;s/ //g')
+          version=$(wget -qO- -t1 -T2 "https://api.github.com/repos/NodeSeekDev/nlist/releases/latest" | grep "tag_name" | head -n 1 | awk -F ":" '{print $2}' | sed 's/\"//g;s/,//g;s/ //g')
           git tag -a $version -m "release $version"
 
       - name: Push tags

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ elif [ "$1" = "beta" ]; then
 else
   git tag -d beta
   version=$(git describe --abbrev=0 --tags)
-  webVersion=$(wget -qO- -t1 -T2 "https://api.github.com/repos/alist-org/alist-web/releases/latest" | grep "tag_name" | head -n 1 | awk -F ":" '{print $2}' | sed 's/\"//g;s/,//g;s/ //g')
+  webVersion=$(wget -qO- -t1 -T2 "https://api.github.com/repos/NodeSeekDev/nlist-web/releases/latest" | grep "tag_name" | head -n 1 | awk -F ":" '{print $2}' | sed 's/\"//g;s/,//g;s/ //g')
 fi
 
 echo "backend version: $version"

--- a/drivers/url_tree/meta.go
+++ b/drivers/url_tree/meta.go
@@ -10,7 +10,7 @@ type Addition struct {
 	// driver.RootPath
 	// driver.RootID
 	// define other
-	UrlStructure string `json:"url_structure" type:"text" required:"true" default:"https://jsd.nn.ci/gh/alist-org/alist/README.md\nhttps://jsd.nn.ci/gh/alist-org/alist/README_cn.md\nfolder:\n  CONTRIBUTING.md:1635:https://jsd.nn.ci/gh/alist-org/alist/CONTRIBUTING.md\n  CODE_OF_CONDUCT.md:2093:https://jsd.nn.ci/gh/alist-org/alist/CODE_OF_CONDUCT.md" help:"structure:FolderName:\n  [FileName:][FileSize:][Modified:]Url"`
+	UrlStructure string `json:"url_structure" type:"text" required:"true" default:"https://cdn.jsdelivr.net/gh/alist-org/alist/README.md\nhttps://cdn.jsdelivr.net/gh/alist-org/alist/README_cn.md\nfolder:\n  CONTRIBUTING.md:1635:https://cdn.jsdelivr.net/gh/alist-org/alist/CONTRIBUTING.md\n  CODE_OF_CONDUCT.md:2093:https://cdn.jsdelivr.net/gh/alist-org/alist/CODE_OF_CONDUCT.md" help:"structure:FolderName:\n  [FileName:][FileSize:][Modified:]Url"`
 	HeadSize     bool   `json:"head_size" type:"bool" default:"false" help:"Use head method to get file size, but it may be failed."`
 	Writable     bool   `json:"writable" type:"bool" default:"false"`
 }

--- a/drivers/url_tree/meta.go
+++ b/drivers/url_tree/meta.go
@@ -10,7 +10,7 @@ type Addition struct {
 	// driver.RootPath
 	// driver.RootID
 	// define other
-	UrlStructure string `json:"url_structure" type:"text" required:"true" default:"https://cdn.jsdelivr.net/gh/alist-org/alist/README.md\nhttps://cdn.jsdelivr.net/gh/alist-org/alist/README_cn.md\nfolder:\n  CONTRIBUTING.md:1635:https://cdn.jsdelivr.net/gh/alist-org/alist/CONTRIBUTING.md\n  CODE_OF_CONDUCT.md:2093:https://cdn.jsdelivr.net/gh/alist-org/alist/CODE_OF_CONDUCT.md" help:"structure:FolderName:\n  [FileName:][FileSize:][Modified:]Url"`
+	UrlStructure string `json:"url_structure" type:"text" required:"true" default:"https://cdn.jsdelivr.net/gh/NodeSeekDev/nlist/README.md\nhttps://cdn.jsdelivr.net/gh/NodeSeekDev/nlist/README_cn.md\nfolder:\n  CONTRIBUTING.md:1635:https://cdn.jsdelivr.net/gh/NodeSeekDev/nlist/CONTRIBUTING.md\n  CODE_OF_CONDUCT.md:2093:https://cdn.jsdelivr.net/gh/NodeSeekDev/nlist/CODE_OF_CONDUCT.md" help:"structure:FolderName:\n  [FileName:][FileSize:][Modified:]Url"`
 	HeadSize     bool   `json:"head_size" type:"bool" default:"false" help:"Use head method to get file size, but it may be failed."`
 	Writable     bool   `json:"writable" type:"bool" default:"false"`
 }

--- a/internal/bootstrap/data/setting.go
+++ b/internal/bootstrap/data/setting.go
@@ -138,7 +138,7 @@ func InitialSettings() []model.SettingItem {
 		//		{Key: conf.PdfViewers, Value: `{
 		//	"pdf.js":"https://alist-org.github.io/pdf.js/web/viewer.html?file=$url"
 		//}`, Type: conf.TypeText, Group: model.PREVIEW},
-		{Key: "audio_cover", Value: "https://jsd.nn.ci/gh/alist-org/logo@main/logo.svg", Type: conf.TypeString, Group: model.PREVIEW},
+		{Key: "audio_cover", Value: "https://cdn.jsdelivr.net/gh/alist-org/logo@main/logo.svg", Type: conf.TypeString, Group: model.PREVIEW},
 		{Key: conf.AudioAutoplay, Value: "true", Type: conf.TypeBool, Group: model.PREVIEW},
 		{Key: conf.VideoAutoplay, Value: "true", Type: conf.TypeBool, Group: model.PREVIEW},
 		{Key: conf.PreviewArchivesByDefault, Value: "true", Type: conf.TypeBool, Group: model.PREVIEW},

--- a/server/static/static.go
+++ b/server/static/static.go
@@ -65,7 +65,7 @@ func UpdateIndex() {
 	mainColor := setting.GetStr(conf.MainColor)
 	conf.ManageHtml = conf.RawIndexHtml
 	replaceMap1 := map[string]string{
-		"https://jsd.nn.ci/gh/alist-org/logo@main/logo.svg": favicon,
+		"https://cdn.jsdelivr.net/gh/alist-org/logo@main/logo.svg": favicon,
 		"Loading...":            title,
 		"main_color: undefined": fmt.Sprintf("main_color: '%s'", mainColor),
 	}


### PR DESCRIPTION
换回原始的jsdelivr，不使用原作者自建镜像。后续发现可信度高的jsdelivr镜像再更改